### PR TITLE
use sendgrid to send emails in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'rails', '~> 6.0.2', '>= 6.0.2.2'
 gem 'sass-rails', '>= 6'
 gem 'turbolinks', '~> 5'
 gem 'webpacker', '~> 4.0'
+gem 'sendgrid_actionmailer_adapter'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,6 +130,8 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -152,6 +154,8 @@ GEM
     puma (4.3.3)
       nio4r (~> 2.0)
     rack (2.2.2)
+    rack-protection (2.0.8.1)
+      rack
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -206,7 +210,9 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.2)
+    ruby2_keywords (0.0.2)
     ruby_dep (1.5.0)
+    ruby_http_client (3.3.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -221,8 +227,18 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sendgrid-ruby (5.3.0)
+      ruby_http_client (~> 3.3.0)
+      sinatra (>= 1.4.7, < 3)
+    sendgrid_actionmailer_adapter (0.3.1)
+      sendgrid-ruby (~> 5.0)
     shoulda-matchers (4.3.0)
       activesupport (>= 4.2.0)
+    sinatra (2.0.8.1)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.8.1)
+      tilt (~> 2.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -288,6 +304,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0.0)
   sass-rails (>= 6)
   selenium-webdriver
+  sendgrid_actionmailer_adapter
   shoulda-matchers
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Coming soon...
 | SMTP_USERNAME | Username for SMTP server |
 | SMTP_PASSWORD | Password for SMTP server |
 | SMTP_PORT     | Port for SMTP server     |
+|SENDGRID_API_KEY| Sendgrid API key (production only |

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,9 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # use sendgrid to send emails
+  config.action_mailer.delivery_method = SendGridActionMailerAdapter::DeliveryMethod
+
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,0 +1,16 @@
+SendGridActionMailerAdapter.configure do |config|
+    # required
+    config.api_key = ENV['SENDGRID_API_KEY']
+    
+    # optional(SendGrid)
+    # config.host = 'host'
+    # config.request_headers = { key: 'val' }
+    # config.version = 'v3'
+    
+    # # optional(Retry)
+    # config.retry_max_count = 3
+    # config.retry_wait_seconds = 3.0
+  
+    # # optional(Others)
+    # config.logger = ::Logger.new(STDOUT)
+  end


### PR DESCRIPTION
instructions followed: https://github.com/ryu39/sendgrid_actionmailer_adapter

a `SENDGRID_API_KEY` variable has been added to the staging and production apps.

