### PR TITLE
Use is_vulnerable instead of priority on contacts

### DIFF
--- a/app/controllers/contacts_controller.rb
+++ b/app/controllers/contacts_controller.rb
@@ -35,6 +35,6 @@ class ContactsController < ApplicationController
   end
 
   def contact_params
-    params.require(:contact).permit(:first_name, :middle_names, :surname, :address, :postcode, :email, :telephone, :mobile, :additional_info, :priority)
+    params.require(:contact).permit(:first_name, :middle_names, :surname, :address, :postcode, :email, :telephone, :mobile, :additional_info, :is_vulnerable)
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -7,8 +7,8 @@ module TasksHelper
     ['To do', 'Completed']
   end
 
-  def task_priorities
-    %w(High Medium Low)
+  def task_is_vulnerable_options
+    ['Vulnerable']
   end
 
   def task_categories

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -9,8 +9,6 @@ class Contact < ApplicationRecord
 
   validates :first_name, presence: true
 
-  enum priority: { low: 'low', medium: 'medium', high: 'high' }, _suffix: true
-  
   def name
     [first_name, surname].join(' ')
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -18,6 +18,6 @@ class Task < ApplicationRecord
 
   validates :name, presence: true
 
-  delegate :name, :priority, to: :contact, prefix: true
+  delegate :name, :is_vulnerable, to: :contact, prefix: true
   delegate :name, to: :user, prefix: true
 end

--- a/app/views/contacts/_form.html.erb
+++ b/app/views/contacts/_form.html.erb
@@ -70,9 +70,29 @@
         <%= form.label :additional_info, class: "field__label" %>
         <%= form.text_area :additional_info %>
       </div>
+
+    </fieldset>
+
+    <fieldset class="field-section field-section--two-cols">
+      <legend><h2 class="field-section__title">Is this person particularly vulnerable or high priority?</h2></legend>
+
+      <div class="notice">
+        <b>By vulnerable we mean:</b>
+        <ul>
+          <li>Over 70 years old</li>
+          <li>Under 70 years old and has an underlying health condition (i.e. normally asked by the NHS to get a flu jab)</li>
+          <li>Pregnant</li>
+        </ul>
+      </div>
+
       <div class="field field--span-two-cols">
-        <%= form.label :priority, class: "field__label" %>
-        <%= form.select :priority, ['low', 'medium', 'high'] %>
+        <%= form.label :is_vulnerable, class: "field__label" %>
+
+        <%= form.radio_button :is_vulnerable, true, :id => "is_vulnerable_true" %>
+        <label for="is_vulnerable_true" class="radio__label">Yes</label>
+
+        <%= form.radio_button :is_vulnerable, false, :id => "is_vulnerable_false" %>
+        <label for="is_vulnerable_false" class="radio__label">No</label>
       </div>
     </fieldset>
 

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -13,7 +13,7 @@
         <th>Assigned</th>
         <th>Name</th>
         <th>Tasks</th>
-        <th>Priority</th>
+        <th>Vulnerable</th>
         <th>Date logged</th>
         <th></th>
         <th></th>
@@ -30,7 +30,9 @@
           <small>(<%= contact.completed_tasks_count %> completed)</small>
         </td>
         <td>
-          <span class="tag"><%= contact.priority %></span>
+          <% if contact.is_vulnerable %>
+            Vulnerable
+          <% end %>
         </td>
         <td><%= contact.created_at.strftime("%-d %B %Y %k:%M%P") %></td>
       </tr>

--- a/app/views/contacts/show.html.erb
+++ b/app/views/contacts/show.html.erb
@@ -1,3 +1,7 @@
+<% if @contact.is_vulnerable %>
+<p class="error">This is a vulnerable person</p>
+<% end %>
+
 <% if notice %>
 <p class="notice"><%= notice %></p>
 <% end %>

--- a/app/views/shared/_tasks_table.html.erb
+++ b/app/views/shared/_tasks_table.html.erb
@@ -6,7 +6,7 @@
       <th>Name</th>
       <th>Need type</th>
       <th style="width: 125px">Status</th>
-      <th style="width: 125px">Priority</th>
+      <th style="width: 125px">Vulnerable</th>
       <th style="width: 125px">Category</th>
       <th>Date logged</th>
     </tr>
@@ -22,7 +22,11 @@
         <td><%= link_to(task.contact_name, contact_path(task.contact.id)) %></td>
         <td><%= link_to task.name, task %></td>
         <td><%= status(task.completed_on) %></td>
-        <td><%= task.contact_priority %></td>
+        <td>
+          <% if task.contact_is_vulnerable %>
+            Vulnerable
+          <% end %>
+        </td>
         <td><%= task.category %>
         <td><%= format_datetime(task.created_at) %></td>
       </tr>
@@ -41,7 +45,7 @@
         <%= select_tag("search_status", options_for_select(task_statuses), prompt: 'Select a status') %>
       </th>
       <th>
-        <%= select_tag("search_priority", options_for_select(task_priorities), prompt: 'Select a priority')  %>
+        <%= select_tag("search_is_vulnerable", options_for_select(task_is_vulnerable_options), prompt: 'Select a vulnerable option')  %>
       </th>
       <th>
         <%= select_tag("search_category", options_for_select(task_categories), prompt: 'Select a category')  %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,3 +1,7 @@
+<% if @contact.is_vulnerable %>
+<p class="error">This is a vulnerable person</p>
+<% end %>
+
 <% if notice %>
   <p class="notice"><%= notice %></p>
 <% end %>
@@ -73,11 +77,6 @@
 
   </div>
   <div class="contact-profile__right">
-    <div class="contact-profile__row">
-      <strong>Priority</strong>
-      <%= @contact.priority %>
-    </div>
-
     <div class="contact-profile__row">
       <strong>Needs:</strong>
       PLACEHOLDER

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,3 +1,7 @@
+<% if @contact.is_vulnerable %>
+<p class="error">This is a vulnerable person</p>
+<% end %>
+
 <% if notice %>
   <p class="notice"><%= notice %></p>
 <% end %>
@@ -54,11 +58,6 @@
 
   </div>
   <div class="contact-profile__right">
-    <div class="contact-profile__row">
-      <strong>Priority</strong>
-      <%= @contact.priority %>
-    </div>
-
     <div class="contact-profile__row">
       <strong>Needs:</strong>
       PLACEHOLDER

--- a/db/migrate/20200331192200_remove_priority_from_contact.rb
+++ b/db/migrate/20200331192200_remove_priority_from_contact.rb
@@ -1,0 +1,5 @@
+class RemovePriorityFromContact < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured { remove_column :contacts, :priority, :string }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_31_160610) do
+ActiveRecord::Schema.define(version: 2020_03_31_192200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,14 +43,12 @@ ActiveRecord::Schema.define(version: 2020_03_31_160610) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "contact_list_id"
-    t.string "priority"
     t.integer "tasks_count", default: 0
     t.integer "uncompleted_tasks_count", default: 0
     t.integer "completed_tasks_count", default: 0
     t.text "email"
     t.string "additional_info"
     t.index ["contact_list_id"], name: "index_contacts_on_contact_list_id"
-    t.index ["priority"], name: "index_contacts_on_priority"
   end
 
   create_table "notes", force: :cascade do |t|

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -9,14 +9,7 @@ FactoryBot.define do
     postcode { Faker::Address.postcode }
     telephone { Faker::PhoneNumber.phone_number }
     mobile { Faker::PhoneNumber.cell_phone }
-    is_vulnerable { true }
-    priority { priorities.sample }
+    is_vulnerable { Faker::Boolean.boolean(true_ratio: 0.3) }
     additional_info {}
-
-    priorities.each do |priority|
-      trait "#{priority}_priority" do
-        priority { priority }
-      end
-    end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe Contact, type: :model do
     it { is_expected.to validate_presence_of :first_name }
   end
 
-  it '.priority' do
-    expect(subject)
-      .to define_enum_for(:priority)
-      .with_values(low: 'low', medium: 'medium', high: 'high')
-      .backed_by_column_of_type(:string)
-      .with_suffix
-  end
-
   it { is_expected.to be_versioned }
 
   it '#name' do


### PR DESCRIPTION
The figma screens seem to use a boolean 'is vulnerable' rather than a 3-tier priority, so I've updated things to reflect that. @jhackett1 this still needs some styling when you have a sec.

Technically this field already existed on the model so we simply dropped the old priority field and started using is_vulnerable.
I also modified the seed factory from 100% true to 30% true.

@jamiebuckley started on similar radio buttons in #33 so may be able to share styling.