### PR TITLE
Improve people list ui

### DIFF
--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -24,8 +24,12 @@
       <tr>
         <td><strong><%= link_to contact.name, contact %></strong></td>
         <td>
-          <%= contact.tasks_count %>
-          <small>(<%= contact.completed_tasks_count %> completed)</small>
+          <% if contact.tasks_count > 0 %>
+            <%= pluralize(contact.uncompleted_tasks_count, 'need') %>
+            <% if contact.completed_tasks_count > 0 %>
+              <small>(<%= contact.completed_tasks_count %> completed)</small>
+            <% end %>
+          <% end %>
         </td>
         <td>
           <span class="tag"><%= contact.priority %></span>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -10,7 +10,6 @@
   <table class="table">
     <thead>
       <tr>
-        <th>Assigned</th>
         <th>Name</th>
         <th>Tasks</th>
         <th>Priority</th>
@@ -23,7 +22,6 @@
     <tbody>
     <% @contacts.each do |contact| %>
       <tr>
-        <td></td>
         <td><strong><%= link_to contact.name, contact %></strong></td>
         <td>
           <%= contact.tasks_count %>


### PR DESCRIPTION
This PR implements:

- Remove "Assigned" column from people list (needs are assigned; not people)
- Emphasise count of incomplete tasks on people list. Shows count of completed tasks, if any, next to it. If no tasks exist, doesn't show anything. (previously this showed the total count of tasks and the number of completed tasks).

<img width="1129" alt="Screenshot 2020-03-31 at 21 27 05" src="https://user-images.githubusercontent.com/761444/78072098-71d08100-7396-11ea-996f-454800554f49.png">
<img width="1154" alt="Screenshot 2020-03-31 at 21 26 53" src="https://user-images.githubusercontent.com/761444/78072102-72691780-7396-11ea-937f-7843da328c25.png">
